### PR TITLE
Implement mission join and leave functionality

### DIFF
--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -1,11 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Alert, Button,
-} from 'react-bootstrap';
+import { Alert, Button } from 'react-bootstrap';
+import { useDispatch } from 'react-redux';
+import { joinMission, leaveMission } from '../redux/missions/missions';
 
 const Mission = (props) => {
-  const { name, description } = props;
+  const {
+    name, description, id, reserved,
+  } = props;
+
+  const dispatch = useDispatch();
+
+  const joinHandle = () => {
+    dispatch(joinMission(id));
+  };
+
+  const leaveHandle = () => {
+    dispatch(leaveMission(id));
+  };
 
   return (
     <tr>
@@ -13,21 +25,39 @@ const Mission = (props) => {
         <h4>{name}</h4>
       </td>
       <td className="w-50">{description}</td>
-      <td className="text-center align-middle">
-        <Alert className="p-0 m-0 bg-extra-dark text-white" variant="dark">
-          NOT A MEMBER
-        </Alert>
-      </td>
-      <td className="text-center align-middle">
-        <Button variant="outline-dark">Join MISSION</Button>
-      </td>
+      {!reserved && (
+      <>
+        <td className="text-center align-middle">
+          <Alert className="p-0 m-0 bg-extra-dark text-white" variant="dark">
+            NOT A MEMBER
+          </Alert>
+        </td>
+        <td className="text-center align-middle"><Button onClick={joinHandle} variant="outline-dark">Join Mission</Button></td>
+      </>
+      )}
+      {reserved && (
+        <>
+          <td className="text-center align-middle">
+            <Alert className="p-0 m-0 bg-dark-blue text-white" variant="info">
+              Active Member
+            </Alert>
+          </td>
+          <td className="text-center align-middle"><Button onClick={leaveHandle} variant="outline-danger">Leave Mission</Button></td>
+        </>
+      )}
     </tr>
   );
+};
+
+Mission.defaultProps = {
+  reserved: false,
 };
 
 Mission.propTypes = {
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
+  reserved: PropTypes.bool,
 };
 
 export default Mission;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,8 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import {
-  Table, Container,
-} from 'react-bootstrap';
+import { Table, Container } from 'react-bootstrap';
 
 import { fetchData } from '../redux/missions/missions';
 import Mission from './Mission';
@@ -31,8 +29,10 @@ const Missions = () => {
           {missionList.map((mission) => (
             <Mission
               key={mission.missionId}
+              id={mission.missionId}
               name={mission.missionName}
               description={mission.description}
+              reserved={mission.reserved}
             />
           ))}
         </tbody>

--- a/src/components/Rockets.js
+++ b/src/components/Rockets.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+
 import { fetchRockets } from '../redux/rockets/rockets';
 
 export default function Rockets() {

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -2,6 +2,7 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import logger from 'redux-logger';
 import thunk from 'redux-thunk';
+
 import missionsReducer from './missions/missions';
 import rocketsReducer from './rockets/rockets';
 

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -3,6 +3,8 @@ import axios from 'axios';
 import * as Camel from '../modules/camelConverter';
 
 const FETCH_DATA = 'FETCH_MISSIONS_DATA';
+const JOIN_MISSION = 'JOIN_MISSION';
+const LEAVE_MISSION = 'LEAVE_MISSION';
 
 const initialState = [];
 
@@ -19,10 +21,38 @@ export const fetchData = () => async (dispatch) => {
   });
 };
 
+export const joinMission = (id) => ({
+  type: JOIN_MISSION,
+  id,
+});
+
+export const leaveMission = (id) => ({
+  type: LEAVE_MISSION,
+  id,
+});
+
 const missionsReducer = (state = initialState, action) => {
   switch (action.type) {
     case FETCH_DATA:
       return action.payload;
+    case JOIN_MISSION: {
+      const newState = state.map((mission) => {
+        if (mission.missionId === action.id) {
+          return { ...mission, reserved: true };
+        }
+        return mission;
+      });
+      return newState;
+    }
+    case LEAVE_MISSION: {
+      const newState = state.map((mission) => {
+        if (mission.missionId === action.id) {
+          return { ...mission, reserved: false };
+        }
+        return mission;
+      });
+      return newState;
+    }
     default:
       return state;
   }

--- a/src/redux/rockets/rockets.js
+++ b/src/redux/rockets/rockets.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+
 import * as Camel from '../modules/camelConverter';
 
 // Action types


### PR DESCRIPTION
### Changes in this branch:

- When a user clicks the "Join Mission" button, the action gets dispatched to update the store. Get the ID of the selected mission and update the state; the state does not get mutated, instead returns a new state object with all missions, but the selected mission will have an extra key `reserved` with its value set to `true`. 

- Place all logic in the reducer. In the React view file, only dispatch the action with the correct rocket ID as an argument.

- Follow the same logic as with the "Join mission" but set the `reserved` key to `false` instead. 

- Dispatch these actions upon clicking on the corresponding buttons.

- Missions that the user has joined already show an "Active Member" badge instead of the default "NOT A MEMBER" and a button "Leave Mission" instead of the "Join Mission" button (as per design).
